### PR TITLE
BUGFIX - encodage issue

### DIFF
--- a/galaxy/camera_annotate/README.rst
+++ b/galaxy/camera_annotate/README.rst
@@ -2,6 +2,10 @@
 Changelog/News
 --------------
 
+**Version 2.2.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 **Version 2.2.0 - 03/02/2017**
 
 - BUGFIX: the diffreport ids didn't convert the rt in minute as the other export

--- a/galaxy/camera_annotate/abims_CAMERA_annotateDiffreport.xml
+++ b/galaxy/camera_annotate/abims_CAMERA_annotateDiffreport.xml
@@ -1,4 +1,4 @@
-<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.0">
+<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.1">
 
     <description>CAMERA annotate function. Returns annotation results (isotope peaks, adducts and fragments) and a diffreport if more than one condition.</description>
 
@@ -423,6 +423,10 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.2.1 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
 
 **Version 2.2.0 - 28/03/2017**
 

--- a/galaxy/camera_combinexsannos/README.rst
+++ b/galaxy/camera_combinexsannos/README.rst
@@ -2,6 +2,11 @@
 Changelog/News
 --------------
 
+**Version 2.0.7 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
+
 **Version 2.0.6 - 10/02/2017**
 
 - IMPROVEMENT: Synchronize the variableMetadata export option with the other tools (xcms.group, xcms.fillpeaks, camera.annotate)
@@ -33,7 +38,7 @@ Changelog/News
 
 **Version 2.0.0 - 09/06/2015**
 
-- NEW: combinexsAnnos Check CAMERA ion species annotation due to matching with opposite ion mode 
+- NEW: combinexsAnnos Check CAMERA ion species annotation due to matching with opposite ion mode
 
 
 Test Status

--- a/galaxy/camera_combinexsannos/abims_CAMERA_combinexsAnnos.xml
+++ b/galaxy/camera_combinexsannos/abims_CAMERA_combinexsAnnos.xml
@@ -1,4 +1,4 @@
-<tool id="abims_CAMERA_combinexsAnnos" name="CAMERA.combinexsAnnos" version="2.0.6">
+<tool id="abims_CAMERA_combinexsAnnos" name="CAMERA.combinexsAnnos" version="2.0.7">
 
     <description>Wrapper function for the combinexsAnnos CAMERA function. Returns a dataframe with recalculated annotations.</description>
 
@@ -208,6 +208,11 @@ Output files
 
 Changelog/News
 --------------
+
+**Version 2.0.7 - 29/11/2017**
+
+- BUGFIX: To avoid issues with accented letter in the parentFile tag of the mzXML files, we changed a hidden mechanim to LC_ALL=C
+
 
 **Version 2.0.6 - 10/02/2017**
 

--- a/galaxy/macro/macros.xml
+++ b/galaxy/macro/macros.xml
@@ -16,7 +16,7 @@
     </xml>
 
     <token name="@COMMAND_CAMERA_SCRIPT@">
-        LANG=C Rscript $__tool_directory__/CAMERA.r
+        LC_ALL=C Rscript $__tool_directory__/CAMERA.r
     </token>
 
     <!-- raw file load for planemo test -->


### PR DESCRIPTION
This input:

```xml
<?xml version="1.0" encoding="ISO-8859-1"?>
    <parentFile fileName="file:///D:/JPA/Laits-2015-06-10-Exactive (Metabolomique R�cap)/./010615007_QC7_.raw"
```

raises this error:
```
Generating EIC's ..
Error in readChar(filename, 1024) : invalid UTF-8 input in readChar()
Calls: annotatediff ... xcmsSource -> xcmsSource -> .local -> <Anonymous> -> readChar
Execution halted
```

xref: https://github.com/workflow4metabolomics/xcms/pull/70