### PR TITLE
update graphicsmagick

### DIFF
--- a/galaxy/macro/macros.xml
+++ b/galaxy/macro/macros.xml
@@ -6,7 +6,7 @@
             <requirement type="package" version="1.38.1">bioconductor-camera</requirement>
             <requirement type="package" version="2.38.0">bioconductor-multtest</requirement>
             <requirement type="package" version="1.1_4">r-batch</requirement>
-            <requirement type="package" version="1.3.26">graphicsmagick</requirement>
+            <requirement type="package" version="1.3.31">graphicsmagick</requirement>
         </requirements>
     </xml>
     <xml name="stdio">


### PR DESCRIPTION
Fix: 
```
$ gm convert TreatedT-vs-ControlT_eic/*.png TreatedT-vs-ControlT_eic.pdf
gm convert: No decode delegate for this image format (TreatedT-vs-ControlT_eic/025.png).
```